### PR TITLE
Fixed atomic populations parsing

### DIFF
--- a/src/fmsio/fileio.py
+++ b/src/fmsio/fileio.py
@@ -409,10 +409,10 @@ def read_geometry():
         # read in geometry
         for i in range(nq):
             lcnt += 1
-            geom_data.extend([float(gm_file[lcnt].rstrip().split()[j])
-                      for j in range(1,len(gm_file[lcnt].rstrip().split()))])
-            crd_dim = len(gm_file[lcnt].rstrip().split()[1:])
-            label_data.extend([gm_file[lcnt].lstrip().rstrip().split()[0]
+            geom_data.extend([float(gm_file[lcnt].split()[j])
+                      for j in range(1,len(gm_file[lcnt].split()))])
+            crd_dim = len(gm_file[lcnt].split()[1:])
+            label_data.extend([gm_file[lcnt].split()[0]
                        for i in range(crd_dim)])
             # if in cartesians, assume mass given in amu, convert to au
             if crd_dim == 3:
@@ -421,14 +421,14 @@ def read_geometry():
         # read in momenta
         for i in range(nq):
             lcnt += 1
-            mom_data.extend([float(gm_file[lcnt].rstrip().split()[j])
-                       for j in range(len(gm_file[lcnt].rstrip().split()))])
+            mom_data.extend([float(gm_file[lcnt].split()[j])
+                       for j in range(len(gm_file[lcnt].split()))])
 
         # read in widths, if present
         if (lcnt+1) < len(gm_file) and 'alpha' in gm_file[lcnt+1]:
             for i in range(nq):
                 lcnt += 1
-                width_data.extend([float(gm_file[lcnt].rstrip().split()[j])
+                width_data.extend([float(gm_file[lcnt].split()[j])
                                for j in range(1,len(gm_file[lcnt].split()))])
         else:
             for lbl in label_data:
@@ -442,7 +442,7 @@ def read_geometry():
         if (lcnt+1) < len(gm_file) and 'mass' in gm_file[lcnt+1]:
             for i in range(nq):
                 lcnt += 1
-                mass_data.extend([float(gm_file[lcnt].rstrip().split()[j]) * mass_conv
+                mass_data.extend([float(gm_file[lcnt].split()[j]) * mass_conv
                                for j in range(1,len(gm_file[lcnt].split()))])
         else:
             for lbl in label_data:
@@ -455,7 +455,7 @@ def read_geometry():
         # read in state, if present
         if (lcnt+1) < len(gm_file) and 'state' in gm_file[lcnt+1]:
             lcnt += 1
-            state_data.append(int(gm_file[lcnt].rstrip().split()[1]))
+            state_data.append(int(gm_file[lcnt].split()[1]))
         else:
             state_data.append(int(-1))
 

--- a/src/interfaces/columbus.py
+++ b/src/interfaces/columbus.py
@@ -550,7 +550,7 @@ def run_col_mrci(traj, ci_restart):
                 mrci_iter = True
             if 'final mr-sdci  convergence information' in line and mrci_iter:
                 for i in range(n_cistates):
-                    ci_info = ofile.readline().lstrip().rstrip().split()
+                    ci_info = ofile.readline().split()
                     try:
                         ci_info.remove('#') # necessary due to unfortunate columbus formatting
                     except ValueError:
@@ -581,11 +581,12 @@ def run_col_mrci(traj, ci_restart):
                 pops = []
                 for i in range(int(np.ceil(n_atoms/6.))):
                     for j in range(max_l+3):
-                        line = ciudgls.readline()
-                    l_arr = line.rstrip().split()
+                        nxtline = ciudgls.readline()
+                        if 'total' in line:
+                            break
+                    l_arr = nxtline.split()
                     pops.extend(l_arr[1:])
-                    line = ciudgls.readline()
-                atom_pops[:, ist] = np.array([float(x) for x in pops])
+                atom_pops[:, ist] = np.array(pops, dtype=float)
 
     # grab mrci output
     append_log(traj.label,'mrci')
@@ -602,7 +603,7 @@ def run_col_mrci(traj, ci_restart):
             shutil.copy(input_path + '/tranin', 'tranin')
             subprocess.run(['tran.x', '-m', mem_str])
 
-    return [energies, atom_pops]
+    return energies, atom_pops
 
 
 def run_col_multipole(traj):
@@ -630,17 +631,17 @@ def run_col_multipole(traj):
                 if 'Dipole moments' in line:
                     for j in range(5):
                         line = prop_file.readline()
-                    l_arr = line.rstrip().split()
+                    l_arr = line.split()
                     dip_moms[:,istate] = np.array([float(l_arr[1]),
                                                    float(l_arr[2]),
                                                    float(l_arr[3])])
                 if 'Second moments' in line:
                     for j in range(5):
                         line = prop_file.readline()
-                    l_arr = line.rstrip().split()
+                    l_arr = line.split()
                     for j in range(5):
                         line = prop_file.readline()
-                    l_arr.extend(line.rstrip().split())
+                    l_arr.extend(line.split())
                     # NOTE: we're only taking the diagonal elements
                     inds = [1,2,3,4,6,7]
                     raw_dat = np.array([float(l_arr[j]) for j in inds])
@@ -698,7 +699,7 @@ def run_col_tdipole(label, state_i, state_j):
     with open('trncils', 'r') as trncils:
         for line in trncils:
             if 'total (elec)' in line:
-                line_arr = line.rstrip().split()
+                line_arr = line.split()
                 for dim in range(p_dim):
                     tran_dip[dim] = float(line_arr[dim+2])
                     tran_dip[dim] = float(line_arr[dim+2])
@@ -1161,11 +1162,11 @@ def ang_mom_dalton(infile):
     with open(infile, 'r') as daltaoin:
         for i in range(4):
             line = daltaoin.readline()
-        l_arr = line.rstrip().split()
+        l_arr = line.split()
         n_grps = int(l_arr[1])
         for i in range(n_grps):
             line = daltaoin.readline()
-            l_arr = line.rstrip().split()
+            l_arr = line.split()
             n_atm = int(l_arr[1])
             n_ang = int(l_arr[2]) - 1
             # max_l on first line
@@ -1176,7 +1177,7 @@ def ang_mom_dalton(infile):
             for j in range(len(n_con)):
                 for k in range(n_con[j]):
                     line = daltaoin.readline()
-                    nprim = int(line.rstrip().split()[1])
+                    nprim = int(line.split()[1])
                     for l in range(nprim):
                         line = daltaoin.readline()
     return max_l


### PR DESCRIPTION
The ciudgls parser was looking atomic populations of each atom up to the maximum azimuthal quantum number. In some cases, H populations can be truncated to lower l values, which now causes a break at the total populations line.